### PR TITLE
Chore update actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,14 +31,14 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3.0.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -10,7 +10,7 @@ jobs:
     name: autoupdate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.0.2
         with:
           ref: develop
 

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
 
-      - uses: peter-evans/create-pull-request@v3.12.1
+      - uses: peter-evans/create-pull-request@v4.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore-update-pre-commit-hooks

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -15,7 +15,7 @@ jobs:
           ref: develop
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v4.1.0
         with:
           python-version: 3.8
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Create Github Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.0.2
 
       - name: Get version from tag
         id: tag_name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get Changelog Entry
         id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2.0.0
+        uses: mindsers/changelog-reader-action@v2.1.1
         with:
           version: ${{ steps.tag_name.outputs.current_version }}
           path: ./CHANGELOG.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.0.2
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v4.1.0
@@ -36,7 +36,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
       fail-fast: true
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v4.1.0
         with:
           python-version: 3.8
 
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v4.1.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - darglint from `^1.8.0` to `^1.8.1`.
 - actions/setup-python from `v2.2.2` to `v4.1.0`.
 - actions/checkout from `v2.4.0` to `v3.0.2`.
+- github/codeql-action from `v1` to `v2`.
 - peter-evans/create-pull-request from `v3.10.1` to `v4.0.4`.
 - mindsers/changelog-reader-action from `v2.0.0` to `v2.1.1`.
 - pre-commit from `^2.15.0` to `^2.18.1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - checkout action from `v2.3.4` to `v2.4.0`.
 - darglint from `^1.8.0` to `^1.8.1`.
 - actions/setup-python from `v2.2.2` to `v4.1.0`.
-- peter-evans/create-pull-request from `v3.10.1` to `v3.12.1`.
+- peter-evans/create-pull-request from `v3.10.1` to `v4.0.4`.
 - mindsers/changelog-reader-action from `v2.0.0` to `v2.1.1`.
 - pre-commit from `^2.15.0` to `^2.18.1`.
 - isort from `^5.9.3` to `^5.10.1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - darglint from `^1.8.0` to `^1.8.1`.
 - actions/setup-python from `v2.2.2` to `v4.1.0`.
 - peter-evans/create-pull-request from `v3.10.1` to `v3.12.1`.
+- mindsers/changelog-reader-action from `v2.0.0` to `v2.1.1`.
 - pre-commit from `^2.15.0` to `^2.18.1`.
 - isort from `^5.9.3` to `^5.10.1`.
 - sphinx from `^4.2.0` to `^4.3.2`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - black from `^21.9b0` to `^22.3.0`.
 - checkout action from `v2.3.4` to `v2.4.0`.
 - darglint from `^1.8.0` to `^1.8.1`.
-- actions/setup-python from `v2.2.2` to `v2.3.1`.
+- actions/setup-python from `v2.2.2` to `v4.1.0`.
 - peter-evans/create-pull-request from `v3.10.1` to `v3.12.1`.
 - pre-commit from `^2.15.0` to `^2.18.1`.
 - isort from `^5.9.3` to `^5.10.1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - checkout action from `v2.3.4` to `v2.4.0`.
 - darglint from `^1.8.0` to `^1.8.1`.
 - actions/setup-python from `v2.2.2` to `v4.1.0`.
+- actions/checkout from `v2.4.0` to `v3.0.2`.
 - peter-evans/create-pull-request from `v3.10.1` to `v4.0.4`.
 - mindsers/changelog-reader-action from `v2.0.0` to `v2.1.1`.
 - pre-commit from `^2.15.0` to `^2.18.1`.

--- a/{{cookiecutter.project_name}}/.github/workflows/codeql-analysis.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3.0.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/{{cookiecutter.project_name}}/.github/workflows/codeql-analysis.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/codeql-analysis.yml
@@ -28,14 +28,14 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1{% endraw %}
+        uses: github/codeql-action/analyze@v2{% endraw %}

--- a/{{cookiecutter.project_name}}/.github/workflows/pre-commit-autoupdate.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/pre-commit-autoupdate.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v4.1.0
         with:
           python-version: 3.8
 

--- a/{{cookiecutter.project_name}}/.github/workflows/pre-commit-autoupdate.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/pre-commit-autoupdate.yml
@@ -10,7 +10,7 @@ jobs:
     name: autoupdate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.0.2
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v4.1.0

--- a/{{cookiecutter.project_name}}/.github/workflows/pre-commit-autoupdate.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/pre-commit-autoupdate.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
 
-      - uses: peter-evans/create-pull-request@v3.12.1
+      - uses: peter-evans/create-pull-request@v4.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore-update-pre-commit-hooks

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v4.1.0
         with:
           python-version: 3.8
 

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Get Changelog Entry
         id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2.0.0
+        uses: mindsers/changelog-reader-action@v2.1.1
         with:
           version: ${{ steps.tag_name.outputs.current_version }}
           path: ./CHANGELOG.md

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.0.2
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v4.1.0
@@ -46,7 +46,7 @@ jobs:
     name: Create Github Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.0.2
 
       - name: Get version from tag
         id: tag_name

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v4.1.0
         with:
           python-version: 3.8
 
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v4.1.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
       
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v4.1.0
         with:
           python-version: 3.8
 

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.0.2
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v4.1.0
@@ -33,7 +33,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
       fail-fast: true
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4.1.0
@@ -70,7 +70,7 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3.0.2
       
       - name: Set up Python 3.8
         uses: actions/setup-python@v4.1.0


### PR DESCRIPTION
## Proposed Changes

  - Bump actions/setup-python from 2.3.1 to 4.1.0
  - Bump mindsers/changelog-reader-action from 2.0.0 to 2.1.1
  - Bump peter-evans/create-pull-request from 3.12.1 to 4.0.4
  - Bump actions/checkout from 2.4.0 to 3.0.2
  - Bump github/codeql-action from 1 to 2
